### PR TITLE
質問投稿フォーム

### DIFF
--- a/src/resources/views/question.blade.php
+++ b/src/resources/views/question.blade.php
@@ -15,37 +15,38 @@
     {{-- データベースまだつくってないので、飛ぶ場所適当 --}}
     <form action="/main" method="POST">
       @csrf
-      <label for="question-problem">
+      <label for="question-problem" class="block mb-2 text-sm font-medium text-gray-900 dark:text-white">
         1,起きている問題
       </label>
-      <textarea placeholder="何を実装したい？" id="question-problem" cols="50" rows="10"></textarea>
+      <textarea placeholder="何を実装したい？" id="question-problem" rows="4" class="block p-2.5 w-full text-sm text-gray-900 bg-gray-50 rounded-lg border border-gray-300 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"></textarea>
 
-      <label for="question-bottleneck">
+      <label for="question-bottleneck" class="block mb-2 text-sm font-medium text-gray-900 dark:text-white">
         2,現状:どこに詰まっている？
       </label>
-      <textarea placeholder="なんのエラーが出てる？" id="question-bottleneck" cols="50" rows="10"></textarea>
+      <textarea placeholder="なんのエラーが出てる？" id="question-bottleneck" cols="50" rows="10" class="block p-2.5 w-full text-sm text-gray-900 bg-gray-50 rounded-lg border border-gray-300 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"></textarea>
 
-      <label for="question-copy">
+      <label for="question-copy" class="block mb-2 text-sm font-medium text-gray-900 dark:text-white">
         3,現状：エラーのコピペ
       </label>
-      <textarea placeholder="何を実装したい？" id="question-copy" cols="50" rows="10"></textarea>
+      <textarea placeholder="何を実装したい？" id="question-copy" cols="50" rows="10" class="block p-2.5 w-full text-sm text-gray-900 bg-gray-50 rounded-lg border border-gray-300 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"></textarea>
 
-      <label for="question-effort">
+      <label for="question-effort" class="block mb-2 text-sm font-medium text-gray-900 dark:text-white">
         4,施策：問題を解決するために試したこと・考えたこと
       </label>
-      <textarea id="question-effort" cols="50" rows="10"></textarea>
+      <textarea id="question-effort" cols="50" rows="10" class="block p-2.5 w-full text-sm text-gray-900 bg-gray-50 rounded-lg border border-gray-300 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"></textarea>
 
-      <label for="question-link">
-        5,GitHubのリンクと、自分がいるブランチ名、問題が起きてるファイル名
-      </label>
-      <input id="question-github-link" placeholder="GitHubのリンク" type="text">
-      <input id="question-branch" placeholder="自分のいるブランチ名" type="text">
-      <input id="question-file" placeholder="問題が起きてるファイル名" type="text">
-
-      <label for="question-reproduce">
+      <div class="mb-6">
+        <label for="question-link" class="block mb-2 text-sm font-medium text-gray-900 dark:text-white">
+          5,GitHubのリンクと、自分がいるブランチ名、問題が起きてるファイル名
+        </label>
+        <input id="question-github-link" placeholder="GitHubのリンク" type="text" class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500">
+        <input id="question-branch" placeholder="自分のいるブランチ名" type="text" class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500">
+        <input id="question-file" placeholder="問題が起きてるファイル名" type="text" class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500">
+      </div>
+      <label for="question-reproduce" class="block mb-2 text-sm font-medium text-gray-900 dark:text-white">
         6,再現手順
       </label>
-      <textarea placeholder="（入るコンテナや使用するパスワードなど）" id="question-reproduce" cols="50" rows="10"></textarea>
+      <textarea placeholder="（入るコンテナや使用するパスワードなど）" id="question-reproduce" cols="50" rows="10" class="block p-2.5 w-full text-sm text-gray-900 bg-gray-50 rounded-lg border border-gray-300 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"></textarea>
     </form>
   </section>
 </body>

--- a/src/resources/views/question.blade.php
+++ b/src/resources/views/question.blade.php
@@ -15,12 +15,36 @@
     {{-- データベースまだつくってないので、飛ぶ場所適当 --}}
     <form action="/main" method="POST">
       @csrf
-      <label for="question-problem">1,起きている問題</label><textarea type="text" placeholder="何を実装したい？" id="question-problem" cols="50" rows="10"></textarea>
-      <label for="question-bottleneck">2,現状:どこに詰まっている？</label><textarea type="text" placeholder="なんのエラーが出てる？" id="question-bottleneck" cols="50" rows="10"></textarea>
-      <label for="question-copy">3,現状：エラーのコピペ</label><textarea type="text" placeholder="何を実装したい？" id="question-copy" cols="50" rows="10"></textarea>
-      <label for="question-effort">4,施策：問題を解決するために試したこと・考えたこと</label><textarea type="text" id="question-effort" cols="50" rows="10"></textarea>
-      <label for="question-link">5,GitHubのリンクと、自分がいるブランチ名、問題が起きてるファイル名</label><textarea type="text" id="question-link" cols="50" rows="10"></textarea>
-      <label for="question-reproduce">6,再現手順</label><textarea type="text" placeholder="（入るコンテナや使用するパスワードなど）" id="question-reproduce" cols="50" rows="10"></textarea>
+      <label for="question-problem">
+        1,起きている問題
+      </label>
+      <textarea placeholder="何を実装したい？" id="question-problem" cols="50" rows="10"></textarea>
+
+      <label for="question-bottleneck">
+        2,現状:どこに詰まっている？
+      </label>
+      <textarea placeholder="なんのエラーが出てる？" id="question-bottleneck" cols="50" rows="10"></textarea>
+
+      <label for="question-copy">
+        3,現状：エラーのコピペ
+      </label>
+      <textarea placeholder="何を実装したい？" id="question-copy" cols="50" rows="10"></textarea>
+
+      <label for="question-effort">
+        4,施策：問題を解決するために試したこと・考えたこと
+      </label>
+      <textarea id="question-effort" cols="50" rows="10"></textarea>
+
+      <label for="question-link">
+        5,GitHubのリンクと、自分がいるブランチ名、問題が起きてるファイル名
+      </label>
+      <input id="question-github-link" placeholder="GitHubのリンク" type="text">
+      <input id="question-branch" placeholder="自分のいるブランチ名" type="text">
+
+      <label for="question-reproduce">
+        6,再現手順
+      </label>
+      <textarea placeholder="（入るコンテナや使用するパスワードなど）" id="question-reproduce" cols="50" rows="10"></textarea>
     </form>
   </section>
 </body>

--- a/src/resources/views/question.blade.php
+++ b/src/resources/views/question.blade.php
@@ -15,12 +15,12 @@
     {{-- データベースまだつくってないので、飛ぶ場所適当 --}}
     <form action="/main" method="POST">
       @csrf
-      <label for="question-problem">1,起きている問題</label><input type="text" placeholder="何を実装したい？" id="question-problem">
-      <label for="question-bottleneck">2,現状:どこに詰まっている？</label><input type="text" placeholder="なんのエラーが出てる？" id="question-bottleneck">
-      <label for="question-copy">3,現状：エラーのコピペ</label><input type="text" placeholder="何を実装したい？" id="question-copy">
-      <label for="question-effort">4,施策：問題を解決するために試したこと・考えたこと</label><input type="text" id="question-effort">
-      <label for="question-link">5,GitHubのリンクと、自分がいるブランチ名、問題が起きてるファイル名</label><input type="text" id="question-link">
-      <label for="question-reproduce">6,再現手順</label><input type="text" placeholder="（入るコンテナや使用するパスワードなど）" id="question-reproduce">
+      <label for="question-problem">1,起きている問題</label><textarea type="text" placeholder="何を実装したい？" id="question-problem" cols="50" rows="10"></textarea>
+      <label for="question-bottleneck">2,現状:どこに詰まっている？</label><textarea type="text" placeholder="なんのエラーが出てる？" id="question-bottleneck" cols="50" rows="10"></textarea>
+      <label for="question-copy">3,現状：エラーのコピペ</label><textarea type="text" placeholder="何を実装したい？" id="question-copy" cols="50" rows="10"></textarea>
+      <label for="question-effort">4,施策：問題を解決するために試したこと・考えたこと</label><textarea type="text" id="question-effort" cols="50" rows="10"></textarea>
+      <label for="question-link">5,GitHubのリンクと、自分がいるブランチ名、問題が起きてるファイル名</label><textarea type="text" id="question-link" cols="50" rows="10"></textarea>
+      <label for="question-reproduce">6,再現手順</label><textarea type="text" placeholder="（入るコンテナや使用するパスワードなど）" id="question-reproduce" cols="50" rows="10"></textarea>
     </form>
   </section>
 </body>

--- a/src/resources/views/question.blade.php
+++ b/src/resources/views/question.blade.php
@@ -40,6 +40,7 @@
       </label>
       <input id="question-github-link" placeholder="GitHubのリンク" type="text">
       <input id="question-branch" placeholder="自分のいるブランチ名" type="text">
+      <input id="question-file" placeholder="問題が起きてるファイル名" type="text">
 
       <label for="question-reproduce">
         6,再現手順

--- a/src/resources/views/question.blade.php
+++ b/src/resources/views/question.blade.php
@@ -15,27 +15,37 @@
     {{-- データベースまだつくってないので、飛ぶ場所適当 --}}
     <form action="/main" method="POST">
       @csrf
-      <label for="question-problem" class="block mb-2 text-sm font-medium text-gray-900 dark:text-white">
-        1,起きている問題
-      </label>
-      <textarea placeholder="何を実装したい？" id="question-problem" rows="4" class="block p-2.5 w-full text-sm text-gray-900 bg-gray-50 rounded-lg border border-gray-300 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"></textarea>
+      {{-- 1,起きている問題 --}}
+      <div class="qustion-first">
+        <label for="question-problem" class="block mb-2 text-sm font-medium text-gray-900 dark:text-white">
+          1,起きている問題
+        </label>
+        <textarea placeholder="何を実装したい？" id="question-problem" rows="4" class="block p-2.5 w-full text-sm text-gray-900 bg-gray-50 rounded-lg border border-gray-300 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"></textarea>
+      </div>
+      {{-- 2,現状:どこに詰まっている？ --}}
+      <div class="question-second">
+        <label for="question-bottleneck" class="block mb-2 text-sm font-medium text-gray-900 dark:text-white">
+          2,現状:どこに詰まっている？
+        </label>
+        <textarea placeholder="なんのエラーが出てる？" id="question-bottleneck" cols="50" rows="10" class="block p-2.5 w-full text-sm text-gray-900 bg-gray-50 rounded-lg border border-gray-300 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"></textarea>
 
-      <label for="question-bottleneck" class="block mb-2 text-sm font-medium text-gray-900 dark:text-white">
-        2,現状:どこに詰まっている？
-      </label>
-      <textarea placeholder="なんのエラーが出てる？" id="question-bottleneck" cols="50" rows="10" class="block p-2.5 w-full text-sm text-gray-900 bg-gray-50 rounded-lg border border-gray-300 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"></textarea>
-
-      <label for="question-copy" class="block mb-2 text-sm font-medium text-gray-900 dark:text-white">
-        3,現状：エラーのコピペ
-      </label>
-      <textarea placeholder="何を実装したい？" id="question-copy" cols="50" rows="10" class="block p-2.5 w-full text-sm text-gray-900 bg-gray-50 rounded-lg border border-gray-300 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"></textarea>
-
-      <label for="question-effort" class="block mb-2 text-sm font-medium text-gray-900 dark:text-white">
-        4,施策：問題を解決するために試したこと・考えたこと
-      </label>
-      <textarea id="question-effort" cols="50" rows="10" class="block p-2.5 w-full text-sm text-gray-900 bg-gray-50 rounded-lg border border-gray-300 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"></textarea>
-
-      <div class="mb-6">
+      </div>
+      {{-- 3,現状：エラーのコピペ --}}
+      <div class="question-third">
+        <label for="question-copy" class="block mb-2 text-sm font-medium text-gray-900 dark:text-white">
+          3,現状：エラーのコピペ
+        </label>
+        <textarea placeholder="何を実装したい？" id="question-copy" cols="50" rows="10" class="block p-2.5 w-full text-sm text-gray-900 bg-gray-50 rounded-lg border border-gray-300 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"></textarea>
+      </div>
+      {{-- 4,施策：問題を解決するために試したこと・考えたこと --}}
+      <div class="qustion-forth">
+        <label for="question-effort" class="block mb-2 text-sm font-medium text-gray-900 dark:text-white">
+          4,施策：問題を解決するために試したこと・考えたこと
+        </label>
+        <textarea id="question-effort" cols="50" rows="10" class="block p-2.5 w-full text-sm text-gray-900 bg-gray-50 rounded-lg border border-gray-300 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"></textarea>
+      </div>
+      {{-- 5,GitHubのリンクと、自分がいるブランチ名、問題が起きてるファイル名 --}}
+      <div class="qustion-fifth mb-6">
         <label for="question-link" class="block mb-2 text-sm font-medium text-gray-900 dark:text-white">
           5,GitHubのリンクと、自分がいるブランチ名、問題が起きてるファイル名
         </label>
@@ -43,10 +53,13 @@
         <input id="question-branch" placeholder="自分のいるブランチ名" type="text" class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500">
         <input id="question-file" placeholder="問題が起きてるファイル名" type="text" class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500">
       </div>
-      <label for="question-reproduce" class="block mb-2 text-sm font-medium text-gray-900 dark:text-white">
-        6,再現手順
-      </label>
-      <textarea placeholder="（入るコンテナや使用するパスワードなど）" id="question-reproduce" cols="50" rows="10" class="block p-2.5 w-full text-sm text-gray-900 bg-gray-50 rounded-lg border border-gray-300 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"></textarea>
+      {{-- 6,再現手順 --}}
+      <div class="question-sixth">
+        <label for="question-reproduce" class="block mb-2 text-sm font-medium text-gray-900 dark:text-white">
+          6,再現手順
+        </label>
+        <textarea placeholder="（入るコンテナや使用するパスワードなど）" id="question-reproduce" cols="50" rows="10" class="block p-2.5 w-full text-sm text-gray-900 bg-gray-50 rounded-lg border border-gray-300 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"></textarea>
+      </div>
     </form>
   </section>
 </body>


### PR DESCRIPTION
- やったこと
> - inputタグをtextareaタグに変更して、複数行入力可能にした。
> - githubリンクとブランチ名、問題が起きてるファイル用のinputを作成
> - 全体のcssをつけた
[inputで使用したサイト](https://flowbite.com/docs/forms/input-field/)
[textareaで使用したサイト](https://flowbite.com/docs/forms/textarea/)
> - それぞれの項目をdivで囲んだ。

- 確認してほしいこと
> - [ ] 全体のcssのデザインが適切についているか

- 困ってること
> - [ ] npm run devを実行しても、サイトを見ることができない。
>> - ここに書いてある設定の変更はしたけど、だめだった。
<img width="1440" alt="Screen Shot 2023-03-11 at 20 24 54" src="https://user-images.githubusercontent.com/107235222/224510061-aec5fda7-f6fa-49ef-a816-6750892f05d8.png">
<img width="1440" alt="Screen Shot 2023-03-11 at 20 25 13" src="https://user-images.githubusercontent.com/107235222/224510079-49d103e9-b847-4892-bf72-5ae416d07e48.png">


- 今後やろうと思ってること
> - [ ] 3,現状：エラーのコピペ、をfileが（エラーのスクショ）がアップデートできる形にする
>> - [ ] また、スクショが１枚じゃない場合もあると思われるので、何枚も写真をアップデートできるようにする方法を考える。
> - [ ] バリデーションを使って、ルール設定。間違った場合の処理。



